### PR TITLE
Implement student status transitions

### DIFF
--- a/packages/express-backend/README.md
+++ b/packages/express-backend/README.md
@@ -1,0 +1,15 @@
+# Express Backend
+
+This package provides the Express.js server for the clock‑in system.
+
+## Student Status
+
+Students now have a `status` field which captures their current lifecycle state:
+
+- `incoming` – newly created student who has not yet checked in.
+- `active` – automatically set after the student's first check‑in.
+- `inactive` – automatically set after the student's final check‑out.
+
+The `CheckIn` model includes middleware that updates the associated student's
+`status` when check‑in records are saved, so no manual status management is
+required.

--- a/packages/express-backend/src/models/CheckIn.ts
+++ b/packages/express-backend/src/models/CheckIn.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, Schema } from 'mongoose';
+import Student from './Student.js';
 
 export interface ICheckIn extends Document {
   studentId: mongoose.Types.ObjectId;
@@ -38,5 +39,14 @@ const checkInSchema: Schema<ICheckIn> = new mongoose.Schema({
 // Index for efficient queries
 checkInSchema.index({ studentId: 1, termId: 1 });
 checkInSchema.index({ timestamp: 1 });
+
+// Middleware to update student status based on check-in type
+checkInSchema.post('save', async function (doc) {
+  if (doc.type === 'in') {
+    await Student.updateOne({ _id: doc.studentId }, { status: 'active' }).exec();
+  } else if (doc.type === 'out') {
+    await Student.updateOne({ _id: doc.studentId }, { status: 'inactive' }).exec();
+  }
+});
 
 export default mongoose.model<ICheckIn>('CheckIn', checkInSchema);

--- a/packages/express-backend/src/models/Student.ts
+++ b/packages/express-backend/src/models/Student.ts
@@ -4,7 +4,7 @@ export interface IStudent extends Document {
   name: string;
   role: string;
   iso: string;
-  isActive: boolean;
+  status: 'incoming' | 'active' | 'inactive';
 }
 
 const studentSchema: Schema<IStudent> = new mongoose.Schema({
@@ -19,14 +19,15 @@ const studentSchema: Schema<IStudent> = new mongoose.Schema({
     required: true,
     unique: true,
   },
-  isActive: {
-    type: Boolean,
-    default: true,
+  status: {
+    type: String,
+    enum: ['incoming', 'active', 'inactive'],
+    default: 'incoming',
   },
 });
 
 // Index for efficient queries
 studentSchema.index({ iso: 1 });
-studentSchema.index({ isActive: 1 });
+studentSchema.index({ status: 1 });
 
 export default mongoose.model<IStudent>('Student', studentSchema);


### PR DESCRIPTION
## Summary
- replace `isActive` boolean with `status` field on Student model
- automatically flip Student status on check-in and check-out
- document status lifecycle in backend README

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --workspace packages/express-backend run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b16523ee883269f3b429bbb2a7f65