### PR TITLE
Add Render deployment workflow

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,47 @@
+name: Render Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trigger Render deploy
+        id: trigger
+        env:
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          deploy_id=$(curl -s -X POST \ 
+            https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys \ 
+            -H "Authorization: Bearer ${RENDER_API_KEY}" \ 
+            -H "Content-Type: application/json" | jq -r '.id')
+          echo "deploy_id=$deploy_id" >> "$GITHUB_OUTPUT"
+
+      - name: Monitor deploy status
+        if: steps.trigger.outputs.deploy_id != ''
+        env:
+          DEPLOY_ID: ${{ steps.trigger.outputs.deploy_id }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          for i in {1..30}; do
+            status=$(curl -s https://api.render.com/v1/deploys/${DEPLOY_ID} \ 
+              -H "Authorization: Bearer ${RENDER_API_KEY}" | jq -r '.status')
+            echo "Status: $status"
+            if [ "$status" = "live" ]; then
+              exit 0
+            fi
+            if [[ "$status" = "build_failed" || "$status" = "update_failed" || "$status" = "deactivated" || "$status" = "canceled" ]]; then
+              echo "Deployment failed"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "Deployment did not complete in time"
+          exit 1


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy via Render on pushes to `main`
- poll Render deploy status and fail the workflow if deployment fails

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b1839c4388326bf41f97aec708184