### PR TITLE
Refactor admin menu into sidebar and pages

### DIFF
--- a/packages/react-frontend/src/app/admin/admin-clock-system.tsx
+++ b/packages/react-frontend/src/app/admin/admin-clock-system.tsx
@@ -1,92 +1,30 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { AlertTriangle } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Navbar } from '../../components/navbar';
 import { DashboardHeader } from '../../components/dashboard-header';
-import { TermManager } from '../../components/term-manager';
 import { StatsCards } from '../../components/stats-cards';
 import { IndividualRecords } from '../../components/individual-records';
-import { StudentManager } from '../../components/student-manager';
 import { TermAnalytics } from '../../components/term-analytics';
 import { TermOverview } from '../../components/term-overview';
-import { initialTerms, initialStaffData } from '../../data/initialData';
 import {
   getCurrentTerm,
   getTermStatus,
   getTermWeekdays,
   getWeeklyStats,
 } from '../../utils/clockUtils';
+import { useAdminData } from './admin-data-context';
 
 export default function AdminClockSystem() {
-  const router = useRouter();
-  const [showStudentManager, setShowStudentManager] = useState(false);
+  const { terms, staffData } = useAdminData();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [dateError, setDateError] = useState('');
-  const [currentTime, setCurrentTime] = useState(new Date());
-  const [showTermManager, setShowTermManager] = useState(false);
-  const [terms, setTerms] = useState(initialTerms);
-  const [staffData, setStaffData] = useState(initialStaffData);
   const [selectedTerm, setSelectedTerm] = useState('Fall 2025');
   const [selectedStaff, setSelectedStaff] = useState(null);
 
-  useEffect(() => {
-    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const handleLogout = () => {
-    router.push('/');
-  };
-
-  const handleAddTerm = (term) => {
-    const newTerm = {
-      ...term,
-      id: Date.now().toString(),
-    };
-    setTerms((prev) => [...prev, newTerm]);
-  };
-
-  const handleEditTerm = (id: string, updatedTerm) => {
-    setTerms((prev) =>
-      prev.map((term) => (term.id === id ? { ...updatedTerm, id } : term))
-    );
-  };
-
-  const handleDeleteTerm = (id: string) => {
-    setTerms((prev) => prev.filter((term) => term.id !== id));
-  };
-
-  const handleAddStudent = (studentData) => {
-    const newStudent = {
-      ...studentData,
-      id: Math.max(...staffData.map((s) => s.id)) + 1,
-      currentStatus: 'expected',
-      todayActual: null,
-      clockEntries: [],
-      assignedLocation: undefined,
-    };
-    setStaffData((prev) => [...prev, newStudent]);
-  };
-
-  const handleEditStudent = (id: number, studentData) => {
-    setStaffData((prev) =>
-      prev.map((staff) =>
-        staff.id === id ? { ...staff, ...studentData } : staff
-      )
-    );
-  };
-
-  const handleDeleteStudent = (id: number) => {
-    setStaffData((prev) => prev.filter((staff) => staff.id !== id));
-    if (selectedStaff?.id === id) {
-      setSelectedStaff(null);
-    }
-  };
 
   const currentTerm = getCurrentTerm(terms, selectedTerm);
   const termWeekdays = getTermWeekdays(currentTerm);
@@ -161,14 +99,6 @@ export default function AdminClockSystem() {
   const stats = getWeeklyStats(staffData);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
-      <Navbar
-        currentTime={currentTime}
-        onLogout={handleLogout}
-        onManageTerms={() => setShowTermManager(true)}
-        onManageStudents={() => setShowStudentManager(true)}
-      />
-
       <div className="max-w-7xl mx-auto px-6">
         <StatsCards
           totalStaff={stats.totalStaff}
@@ -235,26 +165,6 @@ export default function AdminClockSystem() {
           </TabsContent>
         </Tabs>
 
-        {showTermManager && (
-          <TermManager
-            terms={terms}
-            onAddTerm={handleAddTerm}
-            onEditTerm={handleEditTerm}
-            onDeleteTerm={handleDeleteTerm}
-            onClose={() => setShowTermManager(false)}
-          />
-        )}
-
-        {showStudentManager && (
-          <StudentManager
-            staffData={staffData}
-            onAddStudent={handleAddStudent}
-            onEditStudent={handleEditStudent}
-            onDeleteStudent={handleDeleteStudent}
-            onClose={() => setShowStudentManager(false)}
-          />
-        )}
       </div>
-    </div>
   );
 }

--- a/packages/react-frontend/src/app/admin/admin-data-context.tsx
+++ b/packages/react-frontend/src/app/admin/admin-data-context.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { createContext, useContext, useState } from 'react';
+import { Term, Staff } from '@/types';
+import { initialTerms, initialStaffData } from '@/data/initialData';
+
+interface AdminDataContextValue {
+  terms: Term[];
+  addTerm: (term: Omit<Term, 'id'>) => void;
+  editTerm: (id: string, term: Omit<Term, 'id'>) => void;
+  deleteTerm: (id: string) => void;
+  staffData: Staff[];
+  addStudent: (
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus' | 'assignedLocation' | 'todayActual'>
+  ) => void;
+  editStudent: (
+    id: number,
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus' | 'assignedLocation' | 'todayActual'>
+  ) => void;
+  deleteStudent: (id: number) => void;
+}
+
+const AdminDataContext = createContext<AdminDataContextValue | undefined>(undefined);
+
+export function useAdminData() {
+  const context = useContext(AdminDataContext);
+  if (!context) throw new Error('useAdminData must be used within AdminDataProvider');
+  return context;
+}
+
+export function AdminDataProvider({ children }: { children: React.ReactNode }) {
+  const [terms, setTerms] = useState<Term[]>(initialTerms);
+  const [staffData, setStaffData] = useState<Staff[]>(initialStaffData);
+
+  const addTerm = (term: Omit<Term, 'id'>) => {
+    const newTerm = { ...term, id: Date.now().toString() };
+    setTerms((prev) => [...prev, newTerm]);
+  };
+
+  const editTerm = (id: string, updated: Omit<Term, 'id'>) => {
+    setTerms((prev) => prev.map((t) => (t.id === id ? { ...updated, id } : t)));
+  };
+
+  const deleteTerm = (id: string) => {
+    setTerms((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  const addStudent = (
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus' | 'assignedLocation' | 'todayActual'>
+  ) => {
+    const newStudent: Staff = {
+      ...student,
+      id: Math.max(...staffData.map((s) => s.id)) + 1,
+      currentStatus: 'expected',
+      clockEntries: [],
+    };
+    setStaffData((prev) => [...prev, newStudent]);
+  };
+
+  const editStudent = (
+    id: number,
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus' | 'assignedLocation' | 'todayActual'>
+  ) => {
+    setStaffData((prev) => prev.map((s) => (s.id === id ? { ...s, ...student } : s)));
+  };
+
+  const deleteStudent = (id: number) => {
+    setStaffData((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  return (
+    <AdminDataContext.Provider
+      value={{ terms, addTerm, editTerm, deleteTerm, staffData, addStudent, editStudent, deleteStudent }}
+    >
+      {children}
+    </AdminDataContext.Provider>
+  );
+}

--- a/packages/react-frontend/src/app/admin/layout.tsx
+++ b/packages/react-frontend/src/app/admin/layout.tsx
@@ -1,9 +1,104 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Clock, Calendar, Users, LogOut, LayoutDashboard } from 'lucide-react';
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarInset,
+  SidebarTrigger,
+} from '@/components/ui/sidebar';
+import { AdminDataProvider } from './admin-data-context';
 
 export default function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="min-h-screen bg-slate-50">{children}</div>;
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const formatTime = (date: Date) =>
+    date.toLocaleTimeString('en-US', {
+      hour12: true,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+
+  return (
+    <AdminDataProvider>
+      <SidebarProvider>
+        <div className="flex min-h-screen bg-slate-50">
+          <Sidebar>
+            <SidebarHeader>
+              <Link href="/admin" className="flex items-center gap-2 font-semibold">
+                <Clock className="w-5 h-5" />
+                <span>TimeSync</span>
+              </Link>
+            </SidebarHeader>
+            <SidebarContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild>
+                    <Link href="/admin" className="flex items-center gap-2">
+                      <LayoutDashboard className="w-4 h-4" />
+                      <span>Dashboard</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild>
+                    <Link href="/admin/terms" className="flex items-center gap-2">
+                      <Calendar className="w-4 h-4" />
+                      <span>Terms</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild>
+                    <Link href="/admin/students" className="flex items-center gap-2">
+                      <Users className="w-4 h-4" />
+                      <span>Students</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarContent>
+            <SidebarFooter>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild>
+                    <Link href="/" className="flex items-center gap-2 text-red-600">
+                      <LogOut className="w-4 h-4" />
+                      <span>Logout</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarFooter>
+          </Sidebar>
+          <SidebarInset className="flex flex-col w-full">
+            <header className="flex items-center justify-between px-4 py-2 border-b">
+              <SidebarTrigger className="md:hidden" />
+              <div className="font-mono text-sm">{formatTime(currentTime)}</div>
+              <div />
+            </header>
+            <main className="flex-1 p-6">{children}</main>
+          </SidebarInset>
+        </div>
+      </SidebarProvider>
+    </AdminDataProvider>
+  );
 }

--- a/packages/react-frontend/src/app/admin/layout.tsx
+++ b/packages/react-frontend/src/app/admin/layout.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Clock, Calendar, Users, LogOut, LayoutDashboard } from 'lucide-react';
 import {
   SidebarProvider,
@@ -9,6 +10,9 @@ import {
   SidebarContent,
   SidebarHeader,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
@@ -23,6 +27,7 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   const [currentTime, setCurrentTime] = useState(new Date());
+  const pathname = usePathname();
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -41,7 +46,7 @@ export default function AdminLayout({
     <AdminDataProvider>
       <SidebarProvider>
         <div className="flex min-h-screen bg-slate-50">
-          <Sidebar>
+          <Sidebar className="border-r">
             <SidebarHeader>
               <Link href="/admin" className="flex items-center gap-2 font-semibold">
                 <Clock className="w-5 h-5" />
@@ -49,32 +54,37 @@ export default function AdminLayout({
               </Link>
             </SidebarHeader>
             <SidebarContent>
-              <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild>
-                    <Link href="/admin" className="flex items-center gap-2">
-                      <LayoutDashboard className="w-4 h-4" />
-                      <span>Dashboard</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild>
-                    <Link href="/admin/terms" className="flex items-center gap-2">
-                      <Calendar className="w-4 h-4" />
-                      <span>Terms</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild>
-                    <Link href="/admin/students" className="flex items-center gap-2">
-                      <Users className="w-4 h-4" />
-                      <span>Students</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
+              <SidebarGroup>
+                <SidebarGroupLabel>Manage</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={pathname === '/admin'}>
+                        <Link href="/admin" className="flex items-center gap-2">
+                          <LayoutDashboard className="w-4 h-4" />
+                          <span>Dashboard</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={pathname === '/admin/terms'}>
+                        <Link href="/admin/terms" className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4" />
+                          <span>Terms</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={pathname === '/admin/students'}>
+                        <Link href="/admin/students" className="flex items-center gap-2">
+                          <Users className="w-4 h-4" />
+                          <span>Students</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
             </SidebarContent>
             <SidebarFooter>
               <SidebarMenu>
@@ -95,7 +105,9 @@ export default function AdminLayout({
               <div className="font-mono text-sm">{formatTime(currentTime)}</div>
               <div />
             </header>
-            <main className="flex-1 p-6">{children}</main>
+            <main className="flex-1 p-6">
+              <div className="w-full max-w-7xl mx-auto">{children}</div>
+            </main>
           </SidebarInset>
         </div>
       </SidebarProvider>

--- a/packages/react-frontend/src/app/admin/students/page.tsx
+++ b/packages/react-frontend/src/app/admin/students/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { StudentManager } from '../../../components/student-manager';
+import { useAdminData } from '../admin-data-context';
+
+export default function StudentsPage() {
+  const { staffData, addStudent, editStudent, deleteStudent } = useAdminData();
+  return (
+    <StudentManager
+      staffData={staffData}
+      onAddStudent={addStudent}
+      onEditStudent={editStudent}
+      onDeleteStudent={deleteStudent}
+    />
+  );
+}

--- a/packages/react-frontend/src/app/admin/terms/page.tsx
+++ b/packages/react-frontend/src/app/admin/terms/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { TermManager } from '../../../components/term-manager';
+import { useAdminData } from '../admin-data-context';
+
+export default function TermsPage() {
+  const { terms, addTerm, editTerm, deleteTerm } = useAdminData();
+  return (
+    <TermManager
+      terms={terms}
+      onAddTerm={addTerm}
+      onEditTerm={editTerm}
+      onDeleteTerm={deleteTerm}
+    />
+  );
+}

--- a/packages/react-frontend/src/app/globals.css
+++ b/packages/react-frontend/src/app/globals.css
@@ -24,6 +24,14 @@
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
     --radius: 0.5rem;
+    --sidebar-background: 0 0% 98%;
+    --sidebar-foreground: 222.2 47.4% 11.2%;
+    --sidebar-primary: 222.2 47.4% 11.2%;
+    --sidebar-primary-foreground: 210 40% 98%;
+    --sidebar-accent: 210 40% 96.1%;
+    --sidebar-accent-foreground: 222.2 47.4% 11.2%;
+    --sidebar-border: 214.3 31.8% 91.4%;
+    --sidebar-ring: 215 20.2% 65.1%;
   }
 
   .dark {
@@ -46,6 +54,14 @@
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+    --sidebar-background: 224 71% 4%;
+    --sidebar-foreground: 213 31% 91%;
+    --sidebar-primary: 210 40% 98%;
+    --sidebar-primary-foreground: 222.2 47.4% 11.2%;
+    --sidebar-accent: 215 27.9% 16.9%;
+    --sidebar-accent-foreground: 210 40% 98%;
+    --sidebar-border: 215 27.9% 16.9%;
+    --sidebar-ring: 217.2 32.6% 17.5%;
   }
 }
 

--- a/packages/react-frontend/src/components/dashboard-header.tsx
+++ b/packages/react-frontend/src/components/dashboard-header.tsx
@@ -3,14 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { TermSelector } from './term-selector';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-
-interface Term {
-  id: string;
-  name: string;
-  startDate: string;
-  endDate: string;
-  isActive: boolean;
-}
+import { Term } from '@/types';
 
 interface DashboardHeaderProps {
   terms: Term[];

--- a/packages/react-frontend/src/components/student-manager.tsx
+++ b/packages/react-frontend/src/components/student-manager.tsx
@@ -29,52 +29,21 @@ import {
   Trash2,
   Shield,
   UserCheck,
-  X,
   AlertTriangle,
 } from 'lucide-react';
 import { useState } from 'react';
-
-interface ClockEntry {
-  timestamp: string;
-  type: 'in' | 'out';
-  isManual?: boolean;
-}
-
-interface Staff {
-  id: number;
-  name: string;
-  iso: string;
-  role: string;
-  currentStatus: string;
-  weeklySchedule: {
-    monday: string[];
-    tuesday: string[];
-    wednesday: string[];
-    thursday: string[];
-    friday: string[];
-    saturday: string[];
-    sunday: string[];
-  };
-  clockEntries: ClockEntry[];
-}
-
-interface ClockEntry {
-  timestamp: string;
-  type: 'in' | 'out';
-  isManual?: boolean;
-}
+import { Staff } from '@/types';
 
 interface StudentManagerProps {
   staffData: Staff[];
   onAddStudent: (
-    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus' | 'assignedLocation' | 'todayActual'>
   ) => void;
   onEditStudent: (
     id: number,
-    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus' | 'assignedLocation' | 'todayActual'>
   ) => void;
   onDeleteStudent: (id: number) => void;
-  onClose: () => void;
 }
 
 interface DeleteConfirmationModalProps {
@@ -158,7 +127,6 @@ export function StudentManager({
   onAddStudent,
   onEditStudent,
   onDeleteStudent,
-  onClose,
 }: StudentManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -375,17 +343,12 @@ export function StudentManager({
 
   return (
     <>
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <Card className="w-full max-w-6xl max-h-[90vh] overflow-auto">
+      <div className="max-w-6xl mx-auto">
+        <Card className="w-full max-h-[90vh] overflow-auto">
           <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Users className="w-5 h-5" />
-                Manage Students & Staff
-              </div>
-              <Button variant="ghost" size="sm" onClick={onClose}>
-                <X className="w-4 h-4" />
-              </Button>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="w-5 h-5" />
+              Manage Students & Staff
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">

--- a/packages/react-frontend/src/components/term-manager.tsx
+++ b/packages/react-frontend/src/components/term-manager.tsx
@@ -17,21 +17,13 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Calendar, Plus, Edit, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-
-interface Term {
-  id: string;
-  name: string;
-  startDate: string;
-  endDate: string;
-  isActive: boolean;
-}
+import { Term } from '@/types';
 
 interface TermManagerProps {
   terms: Term[];
   onAddTerm: (term: Omit<Term, 'id'>) => void;
   onEditTerm: (id: string, term: Omit<Term, 'id'>) => void;
   onDeleteTerm: (id: string) => void;
-  onClose: () => void;
 }
 
 export function TermManager({
@@ -39,7 +31,6 @@ export function TermManager({
   onAddTerm,
   onEditTerm,
   onDeleteTerm,
-  onClose,
 }: TermManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -80,15 +71,14 @@ export function TermManager({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <Card className="w-full max-w-4xl max-h-[90vh] overflow-auto">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Calendar className="w-5 h-5" />
-            Manage Work Schedule Terms
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6">
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Calendar className="w-5 h-5" />
+          Manage Work Schedule Terms
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
           {/* Add/Edit Form */}
           {isAdding && (
             <Card className="border-2 border-blue-200">
@@ -250,15 +240,7 @@ export function TermManager({
               </Table>
             </CardContent>
           </Card>
-
-          {/* Close Button */}
-          <div className="flex justify-end">
-            <Button onClick={onClose} variant="outline">
-              Close
-            </Button>
-          </div>
         </CardContent>
       </Card>
-    </div>
   );
 }

--- a/packages/react-frontend/src/components/term-manager.tsx
+++ b/packages/react-frontend/src/components/term-manager.tsx
@@ -71,7 +71,7 @@ export function TermManager({
   };
 
   return (
-    <Card className="w-full max-w-4xl mx-auto">
+    <Card className="w-full max-w-6xl mx-auto">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Calendar className="w-5 h-5" />

--- a/packages/react-frontend/src/components/term-selector.tsx
+++ b/packages/react-frontend/src/components/term-selector.tsx
@@ -8,14 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Calendar, ChevronDown } from 'lucide-react';
-
-interface Term {
-  id: string;
-  name: string;
-  startDate: string;
-  endDate: string;
-  isActive: boolean;
-}
+import { Term } from '@/types';
 
 interface TermSelectorProps {
   terms: Term[];

--- a/packages/react-frontend/src/types.ts
+++ b/packages/react-frontend/src/types.ts
@@ -1,0 +1,35 @@
+export interface Term {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  isActive: boolean;
+}
+
+export interface ClockEntry {
+  timestamp: string;
+  type: 'in' | 'out';
+  isManual?: boolean;
+}
+
+export interface WeeklySchedule {
+  monday: string[];
+  tuesday: string[];
+  wednesday: string[];
+  thursday: string[];
+  friday: string[];
+  saturday: string[];
+  sunday: string[];
+}
+
+export interface Staff {
+  id: number;
+  name: string;
+  iso: string;
+  role: string;
+  currentStatus: string;
+  assignedLocation?: string;
+  weeklySchedule: WeeklySchedule;
+  clockEntries: ClockEntry[];
+  todayActual?: string | null;
+}


### PR DESCRIPTION
## Summary
- refactor admin layout to use shadcn sidebar with links to dashboard, terms, and students
- centralize term and student state in a shared AdminDataProvider
- replace modal-based term and student managers with dedicated pages

## Testing
- `npm --workspace packages/react-frontend run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b207685208326ac3810a72f2668d2