### PR TITLE
refactor: split admin management pages

### DIFF
--- a/packages/react-frontend/src/app/admin/admin-data-context.tsx
+++ b/packages/react-frontend/src/app/admin/admin-data-context.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+import { initialTerms, initialStaffData } from '../../data/initialData';
+
+interface Term {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  isActive: boolean;
+}
+
+interface ClockEntry {
+  timestamp: string;
+  type: 'in' | 'out';
+  isManual?: boolean;
+}
+
+interface Staff {
+  id: number;
+  name: string;
+  iso: string;
+  role: string;
+  currentStatus: string;
+  weeklySchedule: {
+    monday: string[];
+    tuesday: string[];
+    wednesday: string[];
+    thursday: string[];
+    friday: string[];
+    saturday: string[];
+    sunday: string[];
+  };
+  clockEntries: ClockEntry[];
+  todayActual?: string | null;
+  assignedLocation?: string;
+}
+
+interface AdminContextType {
+  terms: Term[];
+  addTerm: (term: Omit<Term, 'id'>) => void;
+  editTerm: (id: string, term: Omit<Term, 'id'>) => void;
+  deleteTerm: (id: string) => void;
+  staffData: Staff[];
+  addStudent: (
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
+  ) => void;
+  editStudent: (
+    id: number,
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
+  ) => void;
+  deleteStudent: (id: number) => void;
+}
+
+const AdminDataContext = createContext<AdminContextType | undefined>(undefined);
+
+export function useAdminData() {
+  const context = useContext(AdminDataContext);
+  if (!context) {
+    throw new Error('useAdminData must be used within AdminDataProvider');
+  }
+  return context;
+}
+
+export function AdminDataProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [terms, setTerms] = useState<Term[]>(initialTerms);
+  const [staffData, setStaffData] = useState<Staff[]>(initialStaffData);
+
+  const addTerm = (term: Omit<Term, 'id'>) => {
+    const newTerm = { ...term, id: Date.now().toString() };
+    setTerms((prev) => [...prev, newTerm]);
+  };
+
+  const editTerm = (id: string, term: Omit<Term, 'id'>) => {
+    setTerms((prev) => prev.map((t) => (t.id === id ? { ...term, id } : t)));
+  };
+
+  const deleteTerm = (id: string) => {
+    setTerms((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  const addStudent = (
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
+  ) => {
+    const newStudent: Staff = {
+      ...student,
+      id: Math.max(0, ...staffData.map((s) => s.id)) + 1,
+      currentStatus: 'expected',
+      todayActual: null,
+      clockEntries: [],
+    };
+    setStaffData((prev) => [...prev, newStudent]);
+  };
+
+  const editStudent = (
+    id: number,
+    student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
+  ) => {
+    setStaffData((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, ...student } : s))
+    );
+  };
+
+  const deleteStudent = (id: number) => {
+    setStaffData((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  return (
+    <AdminDataContext.Provider
+      value={{
+        terms,
+        addTerm,
+        editTerm,
+        deleteTerm,
+        staffData,
+        addStudent,
+        editStudent,
+        deleteStudent,
+      }}
+    >
+      {children}
+    </AdminDataContext.Provider>
+  );
+}
+

--- a/packages/react-frontend/src/app/admin/layout.tsx
+++ b/packages/react-frontend/src/app/admin/layout.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { AdminDataProvider } from './admin-data-context';
 
 export default function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="min-h-screen bg-slate-50">{children}</div>;
+  return (
+    <AdminDataProvider>
+      <div className="min-h-screen bg-slate-50">{children}</div>
+    </AdminDataProvider>
+  );
 }

--- a/packages/react-frontend/src/app/admin/students/page.tsx
+++ b/packages/react-frontend/src/app/admin/students/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Navbar } from '../../../components/navbar';
+import { StudentManager } from '../../../components/student-manager';
+import { useAdminData } from '../admin-data-context';
+
+export default function ManageStudentsPage() {
+  const router = useRouter();
+  const { staffData, addStudent, editStudent, deleteStudent } = useAdminData();
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleLogout = () => {
+    router.push('/');
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <Navbar currentTime={currentTime} onLogout={handleLogout} />
+      <div className="max-w-7xl mx-auto px-6">
+        <StudentManager
+          staffData={staffData}
+          onAddStudent={addStudent}
+          onEditStudent={editStudent}
+          onDeleteStudent={deleteStudent}
+          mode="page"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/react-frontend/src/app/admin/terms/page.tsx
+++ b/packages/react-frontend/src/app/admin/terms/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Navbar } from '../../../components/navbar';
+import { TermManager } from '../../../components/term-manager';
+import { useAdminData } from '../admin-data-context';
+
+export default function ManageTermsPage() {
+  const router = useRouter();
+  const { terms, addTerm, editTerm, deleteTerm } = useAdminData();
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleLogout = () => {
+    router.push('/');
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <Navbar currentTime={currentTime} onLogout={handleLogout} />
+      <div className="max-w-7xl mx-auto px-6">
+        <TermManager
+          terms={terms}
+          onAddTerm={addTerm}
+          onEditTerm={editTerm}
+          onDeleteTerm={deleteTerm}
+          mode="page"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/react-frontend/src/components/navbar.tsx
+++ b/packages/react-frontend/src/components/navbar.tsx
@@ -1,38 +1,18 @@
 'use client';
 
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import {
-  Clock,
-  Settings,
-  LogOut,
-  User,
-  Calendar,
-  Users,
-  MapPin,
-} from 'lucide-react';
+import { Clock, LogOut } from 'lucide-react';
 
 interface NavbarProps {
   currentTime: Date;
   onLogout: () => void;
-  onManageTerms: () => void;
-  onManageStudents: () => void;
-  onManageLocations?: () => void;
 }
 
-export function Navbar({
-  currentTime,
-  onLogout,
-  onManageTerms,
-  onManageStudents,
-  onManageLocations,
-}: NavbarProps) {
+export function Navbar({ currentTime, onLogout }: NavbarProps) {
+  const pathname = usePathname();
+
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString('en-US', {
       hour12: true,
@@ -51,6 +31,12 @@ export function Navbar({
     });
   };
 
+  const navItems = [
+    { href: '/admin', label: 'Dashboard' },
+    { href: '/admin/students', label: 'Manage Students' },
+    { href: '/admin/terms', label: 'Manage Terms' },
+  ];
+
   return (
     <nav className="bg-white/80 backdrop-blur-sm border-b border-slate-200 shadow-sm mb-8">
       <div className="max-w-7xl mx-auto px-6 py-4">
@@ -61,12 +47,8 @@ export function Navbar({
               <Clock className="w-6 h-6 text-white" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-slate-900">
-                TimeSync Admin
-              </h1>
-              <p className="text-slate-600 text-sm">
-                IT Service Desk Attendance Management
-              </p>
+              <h1 className="text-2xl font-bold text-slate-900">TimeSync Admin</h1>
+              <p className="text-slate-600 text-sm">IT Service Desk Attendance Management</p>
             </div>
           </div>
 
@@ -75,50 +57,33 @@ export function Navbar({
             <div className="text-lg font-mono font-bold text-slate-900">
               {formatTime(currentTime)}
             </div>
-            <div className="text-sm text-slate-600">
-              {formatDate(currentTime)}
-            </div>
+            <div className="text-sm text-slate-600">{formatDate(currentTime)}</div>
           </div>
 
-          {/* Right - Admin Menu */}
+          {/* Right - Navigation */}
           <div className="flex items-center gap-4">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  className="bg-white border-slate-200 hover:bg-slate-50"
+            <div className="hidden md:flex items-center gap-4">
+              {navItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`text-sm font-medium hover:text-slate-900 ${
+                    pathname === item.href
+                      ? 'text-slate-900 border-b-2 border-slate-900 pb-1'
+                      : 'text-slate-600'
+                  }`}
                 >
-                  <Settings className="w-4 h-4 mr-2" />
-                  Admin Menu
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem>
-                  <User className="w-4 h-4 mr-2" />
-                  Profile
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={onManageTerms}>
-                  <Calendar className="w-4 h-4 mr-2" />
-                  Manage Terms
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={onManageStudents}>
-                  <Users className="w-4 h-4 mr-2" />
-                  Manage Students
-                </DropdownMenuItem>
-                {onManageLocations && (
-                  <DropdownMenuItem onClick={onManageLocations}>
-                    <MapPin className="w-4 h-4 mr-2" />
-                    Manage Locations
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={onLogout} className="text-red-600">
-                  <LogOut className="w-4 h-4 mr-2" />
-                  Logout
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+            <Button
+              onClick={onLogout}
+              variant="outline"
+              className="bg-white border-slate-200 hover:bg-slate-50"
+            >
+              <LogOut className="w-4 h-4 mr-2" /> Logout
+            </Button>
           </div>
         </div>
       </div>

--- a/packages/react-frontend/src/components/student-manager.tsx
+++ b/packages/react-frontend/src/components/student-manager.tsx
@@ -23,6 +23,23 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+import {
   Users,
   Plus,
   Edit,
@@ -30,7 +47,6 @@ import {
   Shield,
   UserCheck,
   X,
-  AlertTriangle,
 } from 'lucide-react';
 import { useState } from 'react';
 
@@ -76,82 +92,6 @@ interface StudentManagerProps {
   onDeleteStudent: (id: number) => void;
   onClose?: () => void;
   mode?: 'modal' | 'page';
-}
-
-interface DeleteConfirmationModalProps {
-  isOpen: boolean;
-  student: Staff | null;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-function DeleteConfirmationModal({
-  isOpen,
-  student,
-  onConfirm,
-  onCancel,
-}: DeleteConfirmationModalProps) {
-  if (!isOpen || !student) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[60]">
-      <Card className="w-full max-w-md shadow-xl border-slate-200">
-        <CardHeader className="pb-3">
-          <CardTitle className="flex items-center gap-2 text-red-700">
-            <AlertTriangle className="w-5 h-5" />
-            Confirm Deletion
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-            <div className="flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5 flex-shrink-0" />
-              <div className="space-y-2">
-                <p className="text-red-800 font-medium">
-                  Are you sure you want to delete{' '}
-                  <strong>{student.name}</strong>?
-                </p>
-                <div className="text-sm text-red-700 space-y-1">
-                  <p>• All clock-in history will be permanently removed</p>
-                  <p>• This action cannot be undone</p>
-                  <p>• ISO: {student.iso}</p>
-                  <p>• Role: {student.role}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-slate-50 border border-slate-200 rounded-lg p-3">
-            <p className="text-sm text-slate-600">
-              <strong>Clock-in History:</strong> {student.clockEntries.length}{' '}
-              entries will be deleted
-            </p>
-          </div>
-
-          <div className="flex gap-3">
-            <Button
-              onClick={onConfirm}
-              className="flex-1 bg-red-600 hover:bg-red-700 text-white"
-            >
-              <Trash2 className="w-4 h-4 mr-2" />
-              Delete Student
-            </Button>
-            <Button
-              onClick={onCancel}
-              variant="outline"
-              className="flex-1 border-slate-200 hover:bg-slate-50"
-            >
-              Cancel
-            </Button>
-          </div>
-
-          <div className="text-xs text-slate-500 text-center">
-            Type the student's name to confirm deletion (coming soon)
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
 }
 
 export function StudentManager({
@@ -393,183 +333,162 @@ export function StudentManager({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
-            {/* Add/Edit Form */}
-            {isAdding && (
-              <Card className="border-2 border-blue-200">
-                <CardHeader>
-                  <CardTitle className="text-lg">
-                    {editingId ? 'Edit Student/Staff' : 'Add New Student/Staff'}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <form onSubmit={handleSubmit} className="space-y-4">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <Label htmlFor="name">Full Name</Label>
-                        <Input
-                          id="name"
-                          value={formData.name}
-                          onChange={(e) =>
-                            setFormData({ ...formData, name: e.target.value })
-                          }
-                          placeholder="e.g., John Smith"
-                          className={errors.name ? 'border-red-500' : ''}
-                        />
-                        {errors.name && (
-                          <p className="text-sm text-red-600 mt-1">
-                            {errors.name}
-                          </p>
-                        )}
-                      </div>
-                      <div>
-                        <Label htmlFor="iso">ISO</Label>
-                        <Input
-                          id="iso"
-                          value={formData.iso}
-                          onChange={(e) =>
-                            setFormData({
-                              ...formData,
-                              iso: e.target.value.toUpperCase(),
-                            })
-                          }
-                          placeholder="e.g., ISO007"
-                          className={errors.iso ? 'border-red-500' : ''}
-                        />
-                        {errors.iso && (
-                          <p className="text-sm text-red-600 mt-1">
-                            {errors.iso}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <Label htmlFor="role">Role</Label>
-                        <Select
-                          value={formData.role}
-                          onValueChange={(value) =>
-                            setFormData({ ...formData, role: value })
-                          }
-                        >
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="Assistant">Assistant</SelectItem>
-                            <SelectItem value="Student Lead">
-                              Student Lead
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      {/* Weekly Schedule Section */}
-                      <div className="col-span-2">
-                        <Label className="text-base font-semibold">
-                          Weekly Schedule
-                        </Label>
-                        <p className="text-sm text-slate-600 mb-4">
-                          Enter time blocks for each day. Examples: "8-11, 12-5"
-                          or "9:00 AM - 5:00 PM"
-                        </p>
-
-                        <div className="space-y-4 max-h-64 overflow-y-auto border rounded-lg p-4">
-                          {Object.entries(formData.weeklySchedule).map(
-                            ([day, blocks]) => (
-                              <div key={day} className="space-y-2">
-                                <div className="flex items-center justify-between">
-                                  <Label className="capitalize font-medium">
-                                    {day}
-                                  </Label>
-                                  <div className="flex items-center gap-2">
-                                    <Input
-                                      placeholder="e.g., 8-11, 12-5"
-                                      className="w-48 text-sm"
-                                      onKeyPress={(e) => {
-                                        if (e.key === 'Enter') {
-                                          const input = e.target.value;
-                                          const timeBlocks =
-                                            parseScheduleInput(input);
-                                          timeBlocks.forEach((block) =>
-                                            addScheduleBlock(day, block)
-                                          );
-                                          e.target.value = '';
-                                        }
-                                      }}
-                                    />
-                                    <Button
-                                      type="button"
-                                      size="sm"
-                                      variant="outline"
-                                      onClick={(e) => {
-                                        const input =
-                                          e.target.previousElementSibling;
-                                        const timeBlocks = parseScheduleInput(
-                                          input.value
-                                        );
-                                        timeBlocks.forEach((block) =>
-                                          addScheduleBlock(day, block)
-                                        );
-                                        input.value = '';
-                                      }}
-                                    >
-                                      Add
-                                    </Button>
-                                  </div>
-                                </div>
-
-                                <div className="flex flex-wrap gap-2 min-h-[2rem]">
-                                  {blocks.length > 0 ? (
-                                    blocks.map((block, index) => (
-                                      <Badge
-                                        key={index}
-                                        variant="secondary"
-                                        className="bg-blue-100 text-blue-800 hover:bg-blue-200 cursor-pointer"
-                                        onClick={() =>
-                                          removeScheduleBlock(day, index)
-                                        }
-                                      >
-                                        {block} ×
-                                      </Badge>
-                                    ))
-                                  ) : (
-                                    <span className="text-sm text-slate-400 italic">
-                                      No schedule set
-                                    </span>
-                                  )}
-                                </div>
+          <Dialog open={isAdding} onOpenChange={(open) => !open && handleCancel()}>
+            <DialogContent className="max-w-4xl">
+              <DialogHeader>
+                <DialogTitle>
+                  {editingId ? 'Edit Student/Staff' : 'Add New Student/Staff'}
+                </DialogTitle>
+              </DialogHeader>
+              <form onSubmit={handleSubmit} className="space-y-4 py-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="name">Full Name</Label>
+                    <Input
+                      id="name"
+                      value={formData.name}
+                      onChange={(e) =>
+                        setFormData({ ...formData, name: e.target.value })
+                      }
+                      placeholder="e.g., John Smith"
+                      className={errors.name ? 'border-red-500' : ''}
+                    />
+                    {errors.name && (
+                      <p className="text-sm text-red-600 mt-1">{errors.name}</p>
+                    )}
+                  </div>
+                  <div>
+                    <Label htmlFor="iso">ISO</Label>
+                    <Input
+                      id="iso"
+                      value={formData.iso}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          iso: e.target.value.toUpperCase(),
+                        })
+                      }
+                      placeholder="e.g., ISO007"
+                      className={errors.iso ? 'border-red-500' : ''}
+                    />
+                    {errors.iso && (
+                      <p className="text-sm text-red-600 mt-1">{errors.iso}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="role">Role</Label>
+                    <Select
+                      value={formData.role}
+                      onValueChange={(value) =>
+                        setFormData({ ...formData, role: value })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Assistant">Assistant</SelectItem>
+                        <SelectItem value="Student Lead">Student Lead</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="col-span-2">
+                    <Label className="text-base font-semibold">
+                      Weekly Schedule
+                    </Label>
+                    <p className="text-sm text-slate-600 mb-4">
+                      Enter time blocks for each day. Examples: "8-11, 12-5" or
+                      "9:00 AM - 5:00 PM"
+                    </p>
+                    <div className="space-y-4 max-h-64 overflow-y-auto border rounded-lg p-4">
+                      {Object.entries(formData.weeklySchedule).map(
+                        ([day, blocks]) => (
+                          <div key={day} className="space-y-2">
+                            <div className="flex items-center justify-between">
+                              <Label className="capitalize font-medium">
+                                {day}
+                              </Label>
+                              <div className="flex items-center gap-2">
+                                <Input
+                                  placeholder="e.g., 8-11, 12-5"
+                                  className="w-48 text-sm"
+                                  onKeyPress={(e) => {
+                                    if (e.key === 'Enter') {
+                                      const input = e.target.value;
+                                      const timeBlocks = parseScheduleInput(
+                                        input
+                                      );
+                                      timeBlocks.forEach((block) =>
+                                        addScheduleBlock(day, block)
+                                      );
+                                      e.target.value = '';
+                                    }
+                                  }}
+                                />
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={(e) => {
+                                    const input =
+                                      (e.target as HTMLElement)
+                                        .previousElementSibling as HTMLInputElement;
+                                    const timeBlocks = parseScheduleInput(
+                                      input.value
+                                    );
+                                    timeBlocks.forEach((block) =>
+                                      addScheduleBlock(day, block)
+                                    );
+                                    input.value = '';
+                                  }}
+                                >
+                                  Add
+                                </Button>
                               </div>
-                            )
-                          )}
-                        </div>
-
-                        <div className="mt-2 text-xs text-slate-500 bg-slate-50 p-2 rounded">
-                          <strong>Tips:</strong>• Enter multiple time blocks
-                          separated by commas (e.g., "8-11, 12-5") • Use 24-hour
-                          format (8-17) or 12-hour format (8 AM - 5 PM) • Click
-                          on time blocks to remove them • Press Enter or click
-                          Add to save time blocks
-                        </div>
-                      </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2 min-h-[2rem]">
+                              {blocks.length > 0 ? (
+                                blocks.map((block, index) => (
+                                  <Badge
+                                    key={index}
+                                    variant="secondary"
+                                    className="bg-blue-100 text-blue-800 hover:bg-blue-200 cursor-pointer"
+                                    onClick={() => removeScheduleBlock(day, index)}
+                                  >
+                                    {block} ×
+                                  </Badge>
+                                ))
+                              ) : (
+                                <span className="text-sm text-slate-400 italic">
+                                  No schedule set
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        )
+                      )}
                     </div>
-                    <div className="flex gap-2">
-                      <Button
-                        type="submit"
-                        className="bg-slate-900 hover:bg-slate-800"
-                      >
-                        {editingId ? 'Update' : 'Add'} Student/Staff
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={handleCancel}
-                      >
-                        Cancel
-                      </Button>
+                    <div className="mt-2 text-xs text-slate-500 bg-slate-50 p-2 rounded">
+                      <strong>Tips:</strong>• Enter multiple time blocks separated
+                      by commas (e.g., "8-11, 12-5") • Use 24-hour format (8-17)
+                      or 12-hour format (8 AM - 5 PM) • Click on time blocks to
+                      remove them • Press Enter or click Add to save time blocks
                     </div>
-                  </form>
-                </CardContent>
-              </Card>
-            )}
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button type="submit" className="bg-slate-900 hover:bg-slate-800">
+                    {editingId ? 'Update' : 'Add'} Student/Staff
+                  </Button>
+                  <Button type="button" variant="outline" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
 
             {/* Add Button */}
             {!isAdding && (
@@ -667,13 +586,31 @@ export function StudentManager({
         </Card>
       </div>
 
-      {/* Delete Confirmation Modal */}
-      <DeleteConfirmationModal
-        isOpen={deleteModal.isOpen}
-        student={deleteModal.student}
-        onConfirm={handleDeleteConfirm}
-        onCancel={handleDeleteCancel}
-      />
+      <AlertDialog
+        open={deleteModal.isOpen}
+        onOpenChange={(open) => !open && handleDeleteCancel()}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete {deleteModal.student?.name}? This
+              action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleDeleteCancel}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/packages/react-frontend/src/components/student-manager.tsx
+++ b/packages/react-frontend/src/components/student-manager.tsx
@@ -74,7 +74,8 @@ interface StudentManagerProps {
     student: Omit<Staff, 'id' | 'clockEntries' | 'currentStatus'>
   ) => void;
   onDeleteStudent: (id: number) => void;
-  onClose: () => void;
+  onClose?: () => void;
+  mode?: 'modal' | 'page';
 }
 
 interface DeleteConfirmationModalProps {
@@ -159,6 +160,7 @@ export function StudentManager({
   onEditStudent,
   onDeleteStudent,
   onClose,
+  mode = 'modal',
 }: StudentManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -375,17 +377,19 @@ export function StudentManager({
 
   return (
     <>
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <Card className="w-full max-w-6xl max-h-[90vh] overflow-auto">
+    <div className={mode === 'modal' ? 'fixed inset-0 bg-black/50 flex items-center justify-center z-50' : ''}>
+        <Card className={mode === 'modal' ? 'w-full max-w-6xl max-h[90vh] overflow-auto' : 'w-full'}>
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Users className="w-5 h-5" />
                 Manage Students & Staff
               </div>
-              <Button variant="ghost" size="sm" onClick={onClose}>
-                <X className="w-4 h-4" />
-              </Button>
+              {mode === 'modal' && onClose && (
+                <Button variant="ghost" size="sm" onClick={onClose}>
+                  <X className="w-4 h-4" />
+                </Button>
+              )}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">

--- a/packages/react-frontend/src/components/term-manager.tsx
+++ b/packages/react-frontend/src/components/term-manager.tsx
@@ -15,6 +15,23 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 import { Calendar, Plus, Edit, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
@@ -51,6 +68,10 @@ export function TermManager({
     endDate: '',
     isActive: false,
   });
+  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean; id: string | null }>({
+    isOpen: false,
+    id: null,
+  });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -81,9 +102,25 @@ export function TermManager({
     setFormData({ name: '', startDate: '', endDate: '', isActive: false });
   };
 
+  const handleDeleteClick = (id: string) => {
+    setDeleteModal({ isOpen: true, id });
+  };
+
+  const handleDeleteConfirm = () => {
+    if (deleteModal.id) {
+      onDeleteTerm(deleteModal.id);
+      setDeleteModal({ isOpen: false, id: null });
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteModal({ isOpen: false, id: null });
+  };
+
   return (
-    <div className={mode === 'modal' ? 'fixed inset-0 bg-black/50 flex items-center justify-center z-50' : ''}>
-      <Card className={mode === 'modal' ? 'w-full max-w-4xl max-h[90vh] overflow-auto' : 'w-full'}>
+    <>
+      <div className={mode === 'modal' ? 'fixed inset-0 bg-black/50 flex items-center justify-center z-50' : ''}>
+        <Card className={mode === 'modal' ? 'w-full max-w-4xl max-h[90vh] overflow-auto' : 'w-full'}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Calendar className="w-5 h-5" />
@@ -91,93 +128,83 @@ export function TermManager({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Add/Edit Form */}
-          {isAdding && (
-            <Card className="border-2 border-blue-200">
-              <CardHeader>
-                <CardTitle className="text-lg">
+          <Dialog open={isAdding} onOpenChange={(open) => !open && handleCancel()}>
+            <DialogContent className="max-w-lg">
+              <DialogHeader>
+                <DialogTitle>
                   {editingId ? 'Edit Term' : 'Add New Term'}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="name">Term Name</Label>
-                      <Input
-                        id="name"
-                        value={formData.name}
-                        onChange={(e) =>
-                          setFormData({ ...formData, name: e.target.value })
-                        }
-                        placeholder="e.g., Fall 2025"
-                        required
-                      />
-                    </div>
-                    <div className="flex items-center space-x-2 pt-6">
-                      <input
-                        type="checkbox"
-                        id="isActive"
-                        checked={formData.isActive}
-                        onChange={(e) =>
-                          setFormData({
-                            ...formData,
-                            isActive: e.target.checked,
-                          })
-                        }
-                        className="rounded"
-                      />
-                      <Label htmlFor="isActive">Active Term</Label>
-                    </div>
+                </DialogTitle>
+              </DialogHeader>
+              <form onSubmit={handleSubmit} className="space-y-4 py-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="name">Term Name</Label>
+                    <Input
+                      id="name"
+                      value={formData.name}
+                      onChange={(e) =>
+                        setFormData({ ...formData, name: e.target.value })
+                      }
+                      placeholder="e.g., Fall 2025"
+                      required
+                    />
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="startDate">Start Date</Label>
-                      <Input
-                        id="startDate"
-                        type="date"
-                        value={formData.startDate}
-                        onChange={(e) =>
-                          setFormData({
-                            ...formData,
-                            startDate: e.target.value,
-                          })
-                        }
-                        required
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="endDate">End Date</Label>
-                      <Input
-                        id="endDate"
-                        type="date"
-                        value={formData.endDate}
-                        onChange={(e) =>
-                          setFormData({ ...formData, endDate: e.target.value })
-                        }
-                        required
-                      />
-                    </div>
+                  <div className="flex items-center space-x-2 pt-6">
+                    <input
+                      type="checkbox"
+                      id="isActive"
+                      checked={formData.isActive}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          isActive: e.target.checked,
+                        })
+                      }
+                      className="rounded"
+                    />
+                    <Label htmlFor="isActive">Active Term</Label>
                   </div>
-                  <div className="flex gap-2">
-                    <Button
-                      type="submit"
-                      className="bg-slate-900 hover:bg-slate-800"
-                    >
-                      {editingId ? 'Update Term' : 'Add Term'}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={handleCancel}
-                    >
-                      Cancel
-                    </Button>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="startDate">Start Date</Label>
+                    <Input
+                      id="startDate"
+                      type="date"
+                      value={formData.startDate}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          startDate: e.target.value,
+                        })
+                      }
+                      required
+                    />
                   </div>
-                </form>
-              </CardContent>
-            </Card>
-          )}
+                  <div>
+                    <Label htmlFor="endDate">End Date</Label>
+                    <Input
+                      id="endDate"
+                      type="date"
+                      value={formData.endDate}
+                      onChange={(e) =>
+                        setFormData({ ...formData, endDate: e.target.value })
+                      }
+                      required
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button type="submit" className="bg-slate-900 hover:bg-slate-800">
+                    {editingId ? 'Update Term' : 'Add Term'}
+                  </Button>
+                  <Button type="button" variant="outline" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
 
           {/* Add Button */}
           {!isAdding && (
@@ -239,7 +266,7 @@ export function TermManager({
                           <Button
                             size="sm"
                             variant="outline"
-                            onClick={() => onDeleteTerm(term.id)}
+                            onClick={() => handleDeleteClick(term.id)}
                             className="text-red-600 hover:text-red-700"
                           >
                             <Trash2 className="w-3 h-3" />
@@ -261,7 +288,34 @@ export function TermManager({
             </div>
           )}
         </CardContent>
-      </Card>
-    </div>
+        </Card>
+      </div>
+
+      <AlertDialog
+        open={deleteModal.isOpen}
+        onOpenChange={(open) => !open && handleDeleteCancel()}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this term? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleDeleteCancel}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/packages/react-frontend/src/components/term-manager.tsx
+++ b/packages/react-frontend/src/components/term-manager.tsx
@@ -31,7 +31,8 @@ interface TermManagerProps {
   onAddTerm: (term: Omit<Term, 'id'>) => void;
   onEditTerm: (id: string, term: Omit<Term, 'id'>) => void;
   onDeleteTerm: (id: string) => void;
-  onClose: () => void;
+  onClose?: () => void;
+  mode?: 'modal' | 'page';
 }
 
 export function TermManager({
@@ -40,6 +41,7 @@ export function TermManager({
   onEditTerm,
   onDeleteTerm,
   onClose,
+  mode = 'modal',
 }: TermManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -80,8 +82,8 @@ export function TermManager({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <Card className="w-full max-w-4xl max-h-[90vh] overflow-auto">
+    <div className={mode === 'modal' ? 'fixed inset-0 bg-black/50 flex items-center justify-center z-50' : ''}>
+      <Card className={mode === 'modal' ? 'w-full max-w-4xl max-h[90vh] overflow-auto' : 'w-full'}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Calendar className="w-5 h-5" />
@@ -251,12 +253,13 @@ export function TermManager({
             </CardContent>
           </Card>
 
-          {/* Close Button */}
-          <div className="flex justify-end">
-            <Button onClick={onClose} variant="outline">
-              Close
-            </Button>
-          </div>
+          {mode === 'modal' && onClose && (
+            <div className="flex justify-end">
+              <Button onClick={onClose} variant="outline">
+                Close
+              </Button>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- add admin data context and wrap admin layout in provider
- replace dropdown admin menu with tabbed nav links
- move term and student management from modals to dedicated pages

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b281d2370832699dd2f1272c6a809